### PR TITLE
[Security] Update lodash for CVE-2018-16487

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1136,9 +1136,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
     "merge-estraverse-visitors": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "eslint": "^5.0.1",
     "espower-loader": "^1.2.2",
     "intelli-espower-loader": "^1.0.1",
+    "lodash": ">=4.17.11",
     "mocha": "^5.2.0",
     "power-assert": "^1.6.0"
   },


### PR DESCRIPTION
I resolved security alert

![image](https://user-images.githubusercontent.com/608755/58844242-4cf57980-86b1-11e9-82cd-a43ca4759038.png)

![image](https://user-images.githubusercontent.com/608755/58844254-5a126880-86b1-11e9-9af6-c9d865e9842b.png)

![image](https://user-images.githubusercontent.com/608755/58844267-65659400-86b1-11e9-91e0-9afc9fea0ceb.png)


c.f. https://nvd.nist.gov/vuln/detail/CVE-2018-16487